### PR TITLE
Fix issues (#D2) | Update to 12.2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ org.gradle.jvmargs=-Xmx1G
 	fabric_version=0.134.0+1.21.8
 
 # Mod Properties
-	mod_version = 12.2
+	mod_version = 12.2.1
 	maven_group = carpet
 	archives_base_name = carpet-pvp
 

--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -473,6 +473,18 @@ public class CarpetSettings
     )
     public static String commandScript = "true";
 
+        @Rule(
+            desc = "Allow Scarpet scripts to intercept item use events (PLAYER_USES_ITEM / PLAYER_FINISHED_USING_ITEM)",
+            category = {SCARPET}
+        )
+        public static boolean scarpetItemUseEvents = true;
+
+        @Rule(
+            desc = "When enabled, players without correct tools will be damaged when hitting tool-required blocks (can be disabled)",
+            category = {SURVIVAL}
+        )
+        public static boolean punishWrongToolHits = true;
+
     private static class ModulePermissionLevel extends Validator<String> {
         @Override public String validate(CommandSourceStack source, CarpetRule<String> currentRule, String newValue, String string) {
             int permissionLevel = switch (newValue) {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "carpet",
-  "version": "12.2",
+  "version": "12.2.1",
   "name": "Carpet PVP",
   "description": "Carpet with some PVP tweaks",
   "authors": [


### PR DESCRIPTION
Fixed: 
- Take damage when breaking a block with the wrong tool and can't break blocks without the right tool even in creative

- Don't regenerate, and items don't increase health; food increases saturation and hunger only briefly, and then after a period of time both go back down to what they originally were 

Disable it by using:
/carpet punishWrongToolHits false