### PR TITLE
issue#54:Fake player death does not increase death count or trigger inventory drop

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -550,17 +550,23 @@ public class CarpetSettings
     )
     public static String commandScript = "true";
 
-        @Rule(
-            desc = "Allow Scarpet scripts to intercept item use events (PLAYER_USES_ITEM / PLAYER_FINISHED_USING_ITEM)",
-            category = {SCARPET}
-        )
-        public static boolean scarpetItemUseEvents = true;
+    @Rule(
+        desc = "Allow Scarpet scripts to intercept item use events (PLAYER_USES_ITEM / PLAYER_FINISHED_USING_ITEM)",
+        category = {SCARPET}
+    )
+    public static boolean scarpetItemUseEvents = true;
 
-        @Rule(
-            desc = "When enabled, players without correct tools will be damaged when hitting tool-required blocks (can be disabled)",
-            category = {SURVIVAL}
-        )
-        public static boolean punishWrongToolHits = true;
+    @Rule(
+        desc = "When enabled, players without correct tools will be damaged when hitting tool-required blocks (can be disabled)",
+        category = {SURVIVAL}
+    )
+    public static boolean punishWrongToolHits = true;
+
+    @Rule(
+        desc = "When enabled, fake players will drop their inventory on death (can be disabled)",
+        category = {SURVIVAL}
+    )
+    public static boolean fakePlayerDropInventoryOnDeath = false;
 
     private static class ModulePermissionLevel extends Validator<String> {
         @Override public String validate(CommandSourceStack source, CarpetRule<String> currentRule, String newValue, String string) {


### PR DESCRIPTION
Updates fake player death behavior to increment deathCount and drop inventory given a new optional setting and when keep_inventory is not set.