### PR TITLE
issue#54:Clean up code, optionally clear bot saved inventory on death

### DIFF
--- a/src/main/java/carpet/CarpetSettings.java
+++ b/src/main/java/carpet/CarpetSettings.java
@@ -563,7 +563,7 @@ public class CarpetSettings
     public static boolean punishWrongToolHits = true;
 
     @Rule(
-        desc = "When enabled, fake players will drop their inventory on death (can be disabled)",
+        desc = "When enabled, fake players will drop their inventory on death",
         category = {SURVIVAL}
     )
     public static boolean fakePlayerDropInventoryOnDeath = false;

--- a/src/main/java/carpet/patches/EntityPlayerMPFake.java
+++ b/src/main/java/carpet/patches/EntityPlayerMPFake.java
@@ -502,11 +502,11 @@ public class EntityPlayerMPFake extends ServerPlayer
     }
 
     protected void dropAllDeathLoot(ServerLevel serverLevel, DamageSource damageSource) {
-        boolean keepInventory = ((net.minecraft.server.level.ServerLevel) this.level()).getGameRules().get(net.minecraft.world.level.gamerules.GameRules.KEEP_INVENTORY);
+        boolean keepInventory = serverLevel.getGameRules().get(net.minecraft.world.level.gamerules.GameRules.KEEP_INVENTORY);
 
         if (!keepInventory) {
+            this.clearSavedEquipmentState();
             this.destroyVanishingCursedItems();
-            //((ServerPlayerInterface)this).getActionPack().drop(-2, true);
             this.getInventory().dropAll();
         }
     }


### PR DESCRIPTION
- Clean up code
- Clear fake player stored inventory on death if option set to drop fake player inventory 